### PR TITLE
Adds ConfigValidator

### DIFF
--- a/app/controllers/github_webhooks_controller.rb
+++ b/app/controllers/github_webhooks_controller.rb
@@ -48,15 +48,29 @@ class GithubWebhooksController < ActionController::Base
 
     files_changed.each do |file|
       file_contents = GithubFileContents.new(repo_name, file[:filename], last_commit).file_content
+      puts '----------------------'
+      puts "filename: #{file[:filename]}"
+      # puts "file_contents: #{file_contents}"
       content_linter_options = { file_contents: file_contents }
+
       file_content_linter = FileContentLinter.new(content_linter_options)
       content_errors = file_content_linter.lint
+
+      puts "content errors: #{content_errors.inspect}"
+      # puts '----------------------'
       if !content_errors.empty?
         content_errors.each do |error|
 
           error_message = error[:message]
           line = error[:line]
           filename = file[:filename]
+          # puts "repo_name: #{repo_name}"
+          # puts "pull_request_number: #{pull_request_number}"
+          # puts "error_message: #{error_message}"
+          # puts "last_commit: #{last_commit}"
+          puts "filename: #{filename}"
+          puts "line: #{line}"
+          puts '=============='
 
           Octokit.create_pull_request_comment(
             repo_name,
@@ -116,7 +130,6 @@ class GithubWebhooksController < ActionController::Base
     lines.each {|line| new_lines << line.split(/\r?\n/)}
     new_lines = new_lines.flatten
     response = find_lines(new_lines[0])
-    # response['diff']
   end
 
   def webhook_secret(payload)

--- a/app/services/config_validator.rb
+++ b/app/services/config_validator.rb
@@ -1,0 +1,32 @@
+require 'pry'
+require 'yaml'
+require 'json'
+
+class ConfigValidator
+
+  def initialize(rules)
+    @rules = rules
+  end
+
+  def validate
+    validate_rules_config
+    validate_rules_config_array
+    validate_rules_config_array_contents
+  end
+
+  private
+
+  def validate_rules_config
+    raise "Invalid config. Top level config key missing" unless rules['config']
+  end
+
+  def validate_rules_config_array
+    raise "Invalid config. Value of 'config' should be an Array" unless rules['config'].is_a? Array
+  end
+
+  def validate_rules_config_array_contents
+    raise "Invalid config. Their are no rules in the configuration" unless rules['config'].any?
+  end
+
+  attr_reader :rules
+end

--- a/app/services/file_content_linter.rb
+++ b/app/services/file_content_linter.rb
@@ -29,7 +29,6 @@ class FileContentLinter
         end
       end
     end
-    # binding.pry
     content_warnings
   end
 
@@ -55,6 +54,7 @@ class FileContentLinter
         warning_response[:reason] = specs['reason']
       end
     end
+    puts "warning_response: #{warning_response}"
     warning_response
   end
 
@@ -78,7 +78,6 @@ class FileContentLinter
     else
       "Consider replacing `#{word}` with #{replacement}."
     end
-    # binding.pry
   end
 
   private

--- a/app/services/file_content_linter.rb
+++ b/app/services/file_content_linter.rb
@@ -4,16 +4,16 @@ require 'json'
 
 class FileContentLinter
 
-  def initialize(options = {})
-    if options[:rules]
-      @rules = options[:rules].freeze
-    else
-      # @rules = YAML.load_file('mdlinter.yml').freeze
-      file = File.read('mdlinter.json')
-      @rules = JSON.parse(file).freeze
-      puts "@rules: #{@rules}"
-    end
-    @file_contents = options[:file_contents]
+  def initialize(file_contents:, file: nil)
+    # @rules = YAML.load_file('mdlinter.yml').freeze
+    file = file || 'mdlinter.json'
+    file = File.read(file)
+    @rules = JSON.parse(file).freeze
+    #{}"#{file_type.capitalize}ConfigValidator".constantize.new(file).validate
+    ConfigValidator.new(@rules).validate
+    # puts "@rules: #{@rules}"
+
+    @file_contents = file_contents
     @warning_types = [
       "replace"
     ]
@@ -31,6 +31,8 @@ class FileContentLinter
     end
     content_warnings
   end
+
+  private
 
   def check_rule(rule, line, index)
     warning_response = {}
@@ -54,7 +56,7 @@ class FileContentLinter
         warning_response[:reason] = specs['reason']
       end
     end
-    puts "warning_response: #{warning_response}"
+    # puts "warning_response: #{warning_response}"
     warning_response
   end
 
@@ -79,8 +81,6 @@ class FileContentLinter
       "Consider replacing `#{word}` with #{replacement}."
     end
   end
-
-  private
 
   attr_reader :file_contents, :rules
 end

--- a/app/services/file_content_linter.rb
+++ b/app/services/file_content_linter.rb
@@ -9,9 +9,8 @@ class FileContentLinter
     file = file || 'mdlinter.json'
     file = File.read(file)
     @rules = JSON.parse(file).freeze
-    #{}"#{file_type.capitalize}ConfigValidator".constantize.new(file).validate
+
     ConfigValidator.new(@rules).validate
-    # puts "@rules: #{@rules}"
 
     @file_contents = file_contents
     @warning_types = [
@@ -56,7 +55,6 @@ class FileContentLinter
         warning_response[:reason] = specs['reason']
       end
     end
-    # puts "warning_response: #{warning_response}"
     warning_response
   end
 

--- a/spec/services/config_validator_spec.rb
+++ b/spec/services/config_validator_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+describe ConfigValidator do
+  context 'config file is an invalid format' do
+    it "raises an error if the first key is not 'config'" do
+      rules = { "something" => "wrong" }
+
+      expect { ConfigValidator.new(rules).validate }.
+        to raise_error RuntimeError, "Invalid config. Top level config key missing"
+    end
+
+    it "raises an error if the value of 'config' is not an Array" do
+      rules = { "config" => "wrong" }
+
+      expect { ConfigValidator.new(rules).validate }.
+        to raise_error RuntimeError, "Invalid config. Value of 'config' should be an Array"
+    end
+
+    it "raises an error if the 'config' Array does not has rules" do
+      rules = { "config" => [] }
+
+      expect { ConfigValidator.new(rules).validate }.
+        to raise_error RuntimeError, "Invalid config. Their are no rules in the configuration"
+    end
+
+    it "does not raise an error if the config is valid" do
+      rules = {
+        "config" => [
+          {
+            "18F-er" => {
+              "replace" => ["18F team members", "18F staffers"],
+              "reason" => "'F-er' can imply profanity"
+            }
+          }
+        ]
+      }
+
+      expect { ConfigValidator.new(rules).validate }.to_not raise_error
+    end
+  end
+end

--- a/spec/services/file_content_linter_spec.rb
+++ b/spec/services/file_content_linter_spec.rb
@@ -73,5 +73,3 @@ describe FileContentLinter do
     end
   end
 end
-
-

--- a/spec/services/file_content_linter_spec.rb
+++ b/spec/services/file_content_linter_spec.rb
@@ -1,91 +1,6 @@
 require 'rails_helper'
 
 describe FileContentLinter do
-  context 'without using default rules' do
-    it 'returns offending lines in a given set of content' do
-
-    file_contents = "18Fers are generally great people.\nThat's why 18F is a great place to work\n"
-
-    linter_rules = {
-      "config"=> [
-        {"18F-er"=>{"replace"=>["18F team member", "18F staffer"], "reason"=>"'F-er' can imply profanity"}},
-        {"18Fer"=>{"replace"=>["18F team member", "18F staffer"], "reason"=>"'F-er' can imply profanity"}},
-        {"backend"=>{"replace"=>["back end", "back end development"]}}
-      ]
-    }
-
-    expected_warning = [
-      {
-        word: "18Fer",
-        line: 1,
-        type: "replace",
-        reason: "'F-er' can imply profanity",
-        replace: ["18F team member", "18F staffer"],
-        message: "Consider replacing `18Fer` with `18F team member` or `18F staffer`. 'F-er' can imply profanity."
-      }
-    ]
-
-    file_content_linter = FileContentLinter.new(
-      { file_contents: file_contents, rules: linter_rules }
-    )
-
-    expect(file_content_linter.lint).to match_array expected_warning
-    end
-
-    it 'finds error for same word on multiple lines' do
-
-      file_contents = "Working for 18F is sometimes great\nBut sometimes we repeat ourselves.\nIn those sometimes it is not so great.\nBeing an 18Fer is fun\n"
-
-      linter_rules = {
-        "config"=> [
-          {"18F-er"=>{"replace"=>["18F team member", "18F staffer"], "reason"=>"'F-er' can imply profanity"}},
-          {"18Fer"=>{"replace"=>["18F team member", "18F staffer"], "reason"=>"'F-er' can imply profanity"}},
-          {"sometimes"=>{"replace"=>["generally"], "reason"=>"plain language"}}
-        ]
-      }
-
-      expected_warning = [
-        {
-          word: "sometimes",
-          line: 1,
-          type: "replace",
-          reason: "plain language",
-          replace: ["generally"],
-          message: "Consider replacing `sometimes` with `generally`. plain language."
-        },
-        {
-          word: "sometimes",
-          line: 2,
-          type: "replace",
-          reason: "plain language",
-          replace: ["generally"],
-          message: "Consider replacing `sometimes` with `generally`. plain language."
-        },
-        {
-          word: "sometimes",
-          line: 3,
-          type: "replace",
-          reason: "plain language",
-          replace: ["generally"],
-          message: "Consider replacing `sometimes` with `generally`. plain language."
-        },
-        {
-          word: "18Fer",
-          line: 4,
-          type: "replace",
-          reason: "'F-er' can imply profanity",
-          replace: ["18F team member", "18F staffer"],
-          message: "Consider replacing `18Fer` with `18F team member` or `18F staffer`. 'F-er' can imply profanity."
-        }
-      ]
-
-      file_content_linter = FileContentLinter.new(
-        { file_contents: file_contents, rules: linter_rules }
-      )
-
-      expect(file_content_linter.lint).to match_array expected_warning
-    end
-  end
   context 'using default rules' do
     it 'returns offending lines in a given set of content' do
       file_contents = "Working for 18F is collaborate great.\n"
@@ -102,10 +17,61 @@ describe FileContentLinter do
       ]
 
       file_content_linter = FileContentLinter.new(
-        { file_contents: file_contents }
+        file_contents: file_contents
+      )
+
+      expect(file_content_linter.lint).to match_array expected_warning
+    end
+  end
+  context 'when config file is specified' do
+    it 'lints the content using the specified file config' do
+      file_contents = "Working for 18F is collaborate great.\n"
+
+      expected_warning = [
+        {
+          word: "collaborate",
+          line: 1,
+          type: "replace",
+          reason: "plain language",
+          replace: ["working with"],
+          message: "Consider replacing `collaborate` with `working with`. plain language."
+        }
+      ]
+
+      file_content_linter = FileContentLinter.new(
+        file_contents: file_contents, file: "#{Rails.root}/spec/support/dummy_mdlinter.json"
+      )
+
+      expect(file_content_linter.lint).to match_array expected_warning
+    end
+
+    it 'finds error for same word on multiple lines' do
+      file_contents = "There is a dropdown that some 18F team members work working on.\nThe dropdown is in the USWDS.\n"
+
+      expected_warning = [
+        {
+          word: "dropdown",
+          line: 1,
+          type: "replace",
+          replace: ["drop-down menu", "drop down"],
+          message: "Consider replacing `dropdown` with `drop-down menu` or `drop down`."
+        },
+        {
+          word: "dropdown",
+          line: 2,
+          type: "replace",
+          replace: ["drop-down menu", "drop down"],
+          message: "Consider replacing `dropdown` with `drop-down menu` or `drop down`."
+        }
+      ]
+
+      file_content_linter = FileContentLinter.new(
+        file_contents: file_contents, file: "#{Rails.root}/spec/support/dummy_mdlinter.json"
       )
 
       expect(file_content_linter.lint).to match_array expected_warning
     end
   end
 end
+
+

--- a/spec/support/dummy_mdlinter.json
+++ b/spec/support/dummy_mdlinter.json
@@ -1,0 +1,72 @@
+{
+    "config": [
+        {
+            "18F-er": {
+                "replace": ["18F team members", "18F staffers"],
+                "reason": "'F-er' can imply profanity"
+            }
+        }, {
+            "18Fer": {
+                "replace": ["18F team members", "18F staffers"],
+                "reason": "'F-er' can imply profanity"
+            }
+        }, {
+            "backend": {
+                "replace": ["back end", "back end development"]
+            }
+        }, {
+            "collaborate": {
+                "replace": ["working with"],
+                "reason": "plain language"
+            }
+        }, {
+            "combating": {
+                "replace": ["working against, fighting"],
+                "reason": "plain language"
+            }
+        }, {
+            "crazy": {
+                "replace": [ "chaotic", "unusual", "complex", "incredible" ]
+            }
+        }, {
+            "dropdown": {
+                "replace": ["drop-down menu", "drop down"]
+            }
+        }, {
+            "elderly": {
+                "replace": ["older person, senior"]
+            }
+        }, {
+            "e-mail": {
+                "cased": true,
+                "replace": ["email"]
+            }
+        }, {
+            "frontend": {
+                "replace": ["front end", "front end development"]
+            }
+        }, {
+            "Open Source": {
+                "cased": true,
+                "replace": ["open source", "open source software"]
+            }
+        }, {
+            "retard": {
+                "replace": ["delay", "hold back"]
+            }
+        }, {
+            "retarded": {
+                "replace": ["delayed", "held back", "silly"]
+            }
+        }, {
+            "user centered design": {
+                "cased": true,
+                "replace": ["user-centered design"]
+            }
+        }, {
+            "user testing": {
+                "replace": ["user research, usability testing"]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Adds a service, ConfigValidator, to validate that the rules configuration (`mdlinter.json`) is properly formatted.

- adds service
- adds corresponding tests
- updates test to take keyword arguments instead of options
- removes unused `puts` statements

cc @monfresh